### PR TITLE
Fix redundant closure clippy warning in generated code.

### DIFF
--- a/gumdrop_derive/src/lib.rs
+++ b/gumdrop_derive/src/lib.rs
@@ -116,7 +116,7 @@ fn derive_options_enum(ast: &DeriveInput, variants: &[Variant]) -> TokenStream {
                     parser: &mut ::gumdrop::Parser<__S>)
                     -> ::std::result::Result<Self, ::gumdrop::Error> {
                 let arg = parser.next_arg()
-                    .ok_or_else(|| ::gumdrop::Error::missing_command())?;
+                    .ok_or_else(::gumdrop::Error::missing_command)?;
 
                 Self::parse_command(arg, parser)
             }


### PR DESCRIPTION
https://github.com/Manishearth/rust-clippy/wiki#redundant_closure

```
error: redundant closure found
   --> src\main.rs:107:17
    |
107 | #[derive(Debug, Options)]
    |                 ^^^^^^^ help: remove closure as shown: `Options`
    |
    = note: #[deny(redundant_closure)] implied by #[deny(clippy)]
```