### PR TITLE
Copy note about help from crate doc to the example

### DIFF
--- a/examples/options.rs
+++ b/examples/options.rs
@@ -16,6 +16,10 @@ struct MyOptions {
 
     // Boolean options are treated as flags, taking no additional values.
     // The optional `help` attribute is displayed in `usage` text.
+    //
+    // A boolean field named `help` is automatically given the `help_flag` attribute.
+    // The `parse_args_or_exit` and `parse_args_default_or_exit` functions use help flags
+    // to automatically display usage to the user.
     #[options(help = "print help message")]
     help: bool,
 


### PR DESCRIPTION
Duplicated the text from the crate header to give extra details about `--help`.

I was browsing the package documentation from [here](https://docs.rs/gumdrop/0.8.0/gumdrop/), but it omits the extra special note that the help_flag is preconfigured. This note is included in the crate header, but not the example/ where I went looking for extra detail about getting it configured.

