### PR TITLE
Argument specification (in usage-line) customization & "smart" default

### DIFF
--- a/gumdrop_derive/src/lib.rs
+++ b/gumdrop_derive/src/lib.rs
@@ -170,6 +170,7 @@ fn derive_options_enum(ast: &DeriveInput, data: &DataEnum)
     let mut help_req_impl = Vec::new();
     let mut variant = Vec::new();
     let usage = make_cmd_usage(&commands);
+    let arg_spec = "[OPTIONS]";
 
     for cmd in commands {
         command.push(cmd.name);
@@ -268,6 +269,10 @@ fn derive_options_enum(ast: &DeriveInput, data: &DataEnum)
                 };
 
                 ::std::result::Result::Ok(cmd)
+            }
+
+            fn argument_spec() -> &'static str {
+                #arg_spec
             }
 
             fn usage() -> &'static str {
@@ -508,6 +513,7 @@ fn derive_options_struct(ast: &DeriveInput, fields: &Fields)
     let name = &ast.ident;
     let opts_help = default_opts.help.or(default_opts.doc);
     let usage = make_usage(&opts_help, &free, &options);
+    let arg_spec = "[OPTIONS]";
 
     let handle_free = if !free.is_empty() {
         let catch_all = if free.last().unwrap().action.is_push() {
@@ -723,6 +729,10 @@ fn derive_options_struct(ast: &DeriveInput, fields: &Fields)
                     -> ::std::result::Result<Self, ::gumdrop::Error> {
                 ::std::result::Result::Err(
                     ::gumdrop::Error::unrecognized_command(name))
+            }
+
+            fn argument_spec() -> &'static str {
+                #arg_spec
             }
 
             fn usage() -> &'static str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ pub trait Options {
                 }
             }
 
-            eprintln!("Usage: {}{} [OPTIONS]", args[0], command_str);
+            eprintln!("Usage: {}{} {}", args[0], command_str, Self::argument_spec());
             eprintln!();
             eprintln!("{}", command.self_usage());
 
@@ -344,6 +344,11 @@ pub trait Options {
 
     /// Parses options for the named command.
     fn parse_command<S: AsRef<str>>(name: &str, parser: &mut Parser<S>) -> Result<Self, Error> where Self: Sized;
+
+    /// Returns a string showing the argument specification.
+    ///
+    /// The returned strings should **not** end with a newline.
+    fn argument_spec() -> &'static str where Self: Sized;
 
     /// Returns a string showing usage and help for each supported option.
     ///


### PR DESCRIPTION
I find the defaut `$argv0 [OPTIONS]` is very bare bones.
A custom spec can now be passed using a new `arg_spec` attribute:
```rust
#[derive(Options)]
#[options(arg_spec = "MY [SPEC]")]
struct MyOptions { ... }
```
Which shows up in the first usage line:
```
$ target/debug/test
Usage: target/debug/test MY [SPEC]
...
```

I've also added some smart option detection, so the default spec can now show `COMMAND`, `OPTIONS` and `ARGS`, with a `...` if multiple are valid and surrounded by `[]` if optional.

If you find this useful I will update the documentation and would also add tests before considering this ready to merge.

I would also like to allow more customization, like formatting the strings as `command` or `<command>` instead of fixating on the current `UPPER_CASE`.
My ultimate vision would also allow generation of a "full" command-spec like `Usage: $argv0 [-h|--help] [-v] [--file FILE] [-- PATHS...]`. This does get unwieldy when a tool has lots of options, so it should definitely be optional. Maybe a user can also tag "important" options to include in the usage-line and leave out the rest.
If I add these I will implement them in separate PRs.