### PR TITLE
fix building with minimal versions

### DIFF
--- a/gumdrop_derive/Cargo.toml
+++ b/gumdrop_derive/Cargo.toml
@@ -24,4 +24,4 @@ default_expr = ["syn/full"]
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = "1.0.3"


### PR DESCRIPTION
syn::Path::get_ident did not exist before 1.0.3

fixes #51